### PR TITLE
fix: update COBTEST1 banner for agent smoke test

### DIFF
--- a/src/COBTEST1.cbl
+++ b/src/COBTEST1.cbl
@@ -1,4 +1,4 @@
-       IDENTIFICATION DIVISION.
+IDENTIFICATION DIVISION.
        PROGRAM-ID. COBTEST1.
 
        ENVIRONMENT DIVISION.
@@ -29,7 +29,7 @@
            *> Obtener fecha actual
            MOVE FUNCTION CURRENT-DATE TO WS-DATETIME
 
-           DISPLAY "== COBTEST1 =="
+           DISPLAY "== COBTEST1 - agent smoke test =="
            DISPLAY "Enter your name: " WITH NO ADVANCING
            ACCEPT WS-NAME
 


### PR DESCRIPTION
This PR updates the COBTEST1.cbl program banner as requested in #12.

- Changes the banner from:
  DISPLAY "== COBTEST1 =="
  to:
  DISPLAY "== COBTEST1 - agent smoke test =="

Fixes #12.